### PR TITLE
feat: load cached missions and refine teleport

### DIFF
--- a/platform/client/ets/chatCommandsClient.cs
+++ b/platform/client/ets/chatCommandsClient.cs
@@ -92,6 +92,7 @@ function initCommandMap()
     commandMapAdd("sos", "sosOperation");
     commandMapAdd(911, "sosOperation");
     commandMapAdd("summon", "summonOperation");
+    commandMapAdd("loadcached", "loadCachedMissionOperation");
     commandMapAdd("talk", "plainSayOperation");
     commandMapAdd("teleport", "teleportOperation");
     commandMapAddAbbreviation("teleport", "tele");
@@ -340,6 +341,12 @@ function teleportOperation(%playerName)
     }
     return ;
 }
+
+function loadCachedMissionOperation(%missionName)
+{
+    loadCachedMission(%missionName);
+    return ;
+}
 function clientCmdRequestCode(%title, %message)
 {
     MessageBoxTextEntry(%title, %message, "enterCodeOperation", "");
@@ -540,8 +547,7 @@ function doUserFavorite(%playerName, %op)
 }
 function doUserTeleportTo(%playerName)
 {
-    %vurl = "vside:/user/" @ %playerName;
-    vurlOperation(%vurl);
+    commandToServer('TeleportToPlayer', %playerName);
     return ;
 }
 function doUserFlyTo(%playerName)

--- a/platform/client/init.cs
+++ b/platform/client/init.cs
@@ -150,6 +150,25 @@ function startStandAlone_Part2()
     log("initialization", "info", "end connectLocal()");
     return ;
 }
+
+function loadCachedMission(%mission)
+{
+    %file = %mission;
+    if (!isFile(%file))
+    {
+        %file = "projects/vside/worlds/" @ %mission @ "/missions/" @ %mission @ ".mis.dbf";
+    }
+    if (!isFile(%file))
+    {
+        error("loadCachedMission: missing file" SPC %file);
+        return ;
+    }
+    $MissionArg = %file;
+    $CacheFlagIsSet = 1;
+    $StandAlone = 1;
+    startStandAlone();
+    return ;
+}
 function join(%joinGameAddress)
 {
     loadMainMenu();

--- a/platform/server/scripts/ets/commandsETS.cs
+++ b/platform/server/scripts/ets/commandsETS.cs
@@ -83,3 +83,31 @@ function ServerCmdSetGenre(%client, %genre)
     %client.Player.setGenre(%genre);
     return ;
 }
+
+function serverCmdTeleportToPlayer(%client, %targetName)
+{
+    if (!isObject(%client.Player))
+    {
+        error("serverCmdTeleportToPlayer: null client player" SPC getDebugString(%client));
+        return ;
+    }
+    %target = PlayerDict.getNorm(%targetName);
+    if (!isObject(%target))
+    {
+        %target = PlayerDict.getNorm(rentabot_makeRentabotName(%targetName));
+    }
+    if (!isObject(%target))
+    {
+        messageClient(%client, 'MsgInfoMessage', 'Invalid teleport target.');
+        return ;
+    }
+    if (%client.Player == %target)
+    {
+        messageClient(%client, 'MsgInfoMessage', 'Cannot teleport to yourself.');
+        return ;
+    }
+    %client.Player.setTransform(%target.getTransform());
+    %client.Player.setVelocity("0 0 0");
+    messageClient(%client, 'MsgInfoMessage', 'Teleported to' SPC %target.getShapeName() @ '.');
+    return ;
+}


### PR DESCRIPTION
## Summary
- allow users to teleport to another player with `/teleport <name>` from chat
- load local `.mis.dbf` missions with `/loadcached <name>` or `loadCachedMission(<path>)`
- prevent teleporting to yourself and report success on teleport

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d253faea48328b825059c570c1629

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a “loadcached” chat command to load a cached mission.
  - Added support to launch cached missions in standalone mode with automatic fallback resolution.
- Bug Fixes
  - Teleportation to another player now runs on the server with proper validation and feedback, preventing self-teleports and invalid targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->